### PR TITLE
Fix manage.py check

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,26 @@
 #!/usr/bin/env python
 import os
 import sys
+from django.utils import encoding
+from django.http import HttpResponse
+from django.template import loader
+import django.shortcuts as shortcuts
+
+if not hasattr(encoding, "smart_text"):
+    encoding.smart_text = encoding.smart_str
+
+if not hasattr(shortcuts, "render_to_response"):
+    def render_to_response(
+        template_name,
+        context=None,
+        content_type=None,
+        status=None,
+        using=None,
+    ):
+        content = loader.render_to_string(template_name, context, using=using)
+        return HttpResponse(content, content_type=content_type, status=status)
+
+    shortcuts.render_to_response = render_to_response
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mcp_server.settings')

--- a/mcp_server/api/api.py
+++ b/mcp_server/api/api.py
@@ -124,7 +124,7 @@ def get_merge_request_ci_status(
     )
     if pipelines:
         pipeline_id = pipelines[0].get('id')
-        pipeline = gitlab_request(
+        gitlab_request(
             'GET',
             f'/projects/{project_id}/pipelines/{pipeline_id}',
         )

--- a/mcp_server/jsonrpc_urls.py
+++ b/mcp_server/jsonrpc_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from jsonrpc.site import jsonrpc_site
+from jsonrpc import views
+
+urlpatterns = [
+    path('', jsonrpc_site.dispatch, name='jsonrpc'),
+    path('browse/', views.browse, name='jsonrpc-browse'),
+]

--- a/mcp_server/settings.py
+++ b/mcp_server/settings.py
@@ -15,7 +15,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'jsonrpc',
-    'api',
+    'mcp_server.api',
 ]
 
 MIDDLEWARE = [
@@ -51,7 +51,7 @@ WSGI_APPLICATION = 'mcp_server.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'NAME': str(BASE_DIR / 'db.sqlite3'),
     }
 }
 

--- a/mcp_server/urls.py
+++ b/mcp_server/urls.py
@@ -3,5 +3,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('rpc/', include('jsonrpc.urls')),
+    path('rpc/', include('mcp_server.jsonrpc_urls')),
 ]


### PR DESCRIPTION
## Summary
- fix compatibility with django-json-rpc on Django 5
- add jsonrpc URL patterns inside project
- remove unused variable in API
- fix database path handling

## Testing
- `flake8 --exclude=.venv`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68698f8e8330832fbb8d05cc05446ee0