### PR TITLE
Add OpenAPI endpoint for JSON‑RPC methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ python manage.py runserver 8000
 
 The JSON-RPC endpoint will be available at `http://localhost:8000/rpc/`.
 
+An OpenAPI description of the available RPC methods can be fetched from
+`http://localhost:8000/openapi.json` once the server is running. This file can
+be used by tools that expect an OpenAPI schema to discover the available
+functions automatically.
+
 ## Continuous Integration
 
 The project includes a GitHub Actions workflow that installs dependencies,

--- a/mcp_server/openapi.py
+++ b/mcp_server/openapi.py
@@ -1,0 +1,51 @@
+from django.http import JsonResponse
+from jsonrpc.site import jsonrpc_site
+
+
+def openapi_schema(request):
+    desc = jsonrpc_site.service_desc()
+    paths = {}
+    for proc in desc.get('procs', []):
+        name = proc.get('name')
+        params = proc.get('params', [])
+        param_props = {}
+        required = []
+        for p in params:
+            param_props[p['name']] = {'type': 'string'}
+            required.append(p['name'])
+        request_schema = {
+            'type': 'object',
+            'properties': {
+                'jsonrpc': {'type': 'string', 'enum': ['2.0']},
+                'method': {'type': 'string', 'enum': [name]},
+                'params': {
+                    'type': 'object',
+                    'properties': param_props,
+                    'required': required,
+                },
+                'id': {'type': 'integer'},
+            },
+            'required': ['jsonrpc', 'method', 'id'],
+        }
+        paths[f'/{name}'] = {
+            'post': {
+                'summary': proc.get('summary') or '',
+                'requestBody': {
+                    'content': {
+                        'application/json': {'schema': request_schema}
+                    }
+                },
+                'responses': {
+                    '200': {'description': 'JSON-RPC response'}
+                },
+            }
+        }
+    schema = {
+        'openapi': '3.0.0',
+        'info': {
+            'title': desc.get('name', 'GitLab MCP'),
+            'version': desc.get('version', '1.0'),
+        },
+        'paths': paths,
+    }
+    return JsonResponse(schema)

--- a/mcp_server/urls.py
+++ b/mcp_server/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
 
+from .openapi import openapi_schema
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('rpc/', include('mcp_server.jsonrpc_urls')),
+    path('openapi.json', openapi_schema, name='openapi-schema'),
 ]


### PR DESCRIPTION
## Summary
- expose `/openapi.json` route that generates an OpenAPI schema from registered JSON‑RPC methods
- document the new OpenAPI endpoint in the README

## Testing
- `./.venv/bin/flake8 . --exclude=.venv`
- `./.venv/bin/python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6869a55a81cc832fa8dd5626d3f66997