### PR TITLE
Add GitLab tools and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r clean_mcp_init/requirements.txt
+      - name: Run tests
+        run: python clean_mcp_init/manage.py test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Clean MCP Init
+
+This repository contains a minimal Django project configured with FastMCP.
+It exposes a handful of MCP tools including a simple `add` example and a few
+helpers for interacting with the GitLab API.  See `clean_mcp_init/mcp_tools.py`
+for the tool definitions.
+
+## Development
+
+Install requirements and run the tests:
+
+```bash
+pip install -r clean_mcp_init/requirements.txt
+python clean_mcp_init/manage.py test
+```
+
+The ASGI application is defined in `clean_mcp_init/asgi.py` and mounts the
+MCP server at `/mcp`.

--- a/clean_mcp_init/clean_mcp_init/asgi.py
+++ b/clean_mcp_init/clean_mcp_init/asgi.py
@@ -1,21 +1,18 @@
-"""
-ASGI entry-point for clean_mcp_init.
-Serves normal Django views + an MCP endpoint at /mcp
-"""
+"""ASGI entry-point for clean_mcp_init."""
 
-import os, django
+import os
+import django
+
 import clean_mcp_init.mcp_tools
 from django.core.asgi import get_asgi_application
-from django_mcp import mount_mcp_server        # ← import the helper  :contentReference[oaicite:1]{index=1}
+from django_mcp import mount_mcp_server
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "clean_mcp_init.settings")
 django.setup()
 
-# Plain Django app (admin, REST routes, …)
 django_http_app = get_asgi_application()
 
-# Wrap it with the MCP router
 application = mount_mcp_server(
     django_http_app=django_http_app,
-    mcp_base_path="/mcp",        # exact URL you’ll POST to (no trailing slash)
+    mcp_base_path="/mcp",
 )

--- a/clean_mcp_init/clean_mcp_init/gitlab_utils.py
+++ b/clean_mcp_init/clean_mcp_init/gitlab_utils.py
@@ -1,0 +1,101 @@
+"""Utility helpers for interacting with the GitLab API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+try:
+    import requests
+except Exception:  # pragma: no cover - fallback for environments without requests
+    requests = None
+    import json
+    from urllib import request as urllib_request
+
+    class _Resp:
+        def __init__(self, resp: urllib_request.addinfourl):
+            self._resp = resp
+            self.status_code = resp.getcode()
+
+        def json(self):
+            return json.loads(self._resp.read().decode())
+
+        def raise_for_status(self):
+            if not (200 <= self.status_code < 300):
+                raise ValueError(f"HTTP {self.status_code}")
+
+    def _http_call(method: str, url: str, *, headers=None, data=None, params=None):
+        if params:
+            import urllib.parse
+            url += "?" + urllib.parse.urlencode(params)
+        req = urllib_request.Request(url, data=data, headers=headers or {}, method=method.upper())
+        return _Resp(urllib_request.urlopen(req))
+
+    class requests:  # type: ignore
+        @staticmethod
+        def get(url, headers=None, params=None):
+            return _http_call("GET", url, headers=headers, params=params)
+
+        @staticmethod
+        def post(url, headers=None, json=None):
+            data = None
+            if json is not None:
+                data = json.__class__.__name__ != 'str' and bytes(__import__('json').dumps(json), 'utf-8') or json
+                headers = headers or {}
+                headers.setdefault('Content-Type', 'application/json')
+            return _http_call("POST", url, headers=headers, data=data)
+
+GITLAB_API_URL = os.environ.get("GITLAB_API_URL", "https://gitlab.com/api/v4")
+GITLAB_TOKEN = os.environ.get("GITLAB_TOKEN")
+
+
+def _headers() -> dict[str, str]:
+    headers = {}
+    if GITLAB_TOKEN:
+        headers["PRIVATE-TOKEN"] = GITLAB_TOKEN
+    return headers
+
+
+def get_merge_requests(project_id: int, branch_name: str) -> list[dict[str, Any]]:
+    """Return merge requests for the given branch name."""
+    resp = requests.get(
+        f"{GITLAB_API_URL}/projects/{project_id}/merge_requests",
+        headers=_headers(),
+        params={"source_branch": branch_name},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_merge_request_comments(project_id: int, mr_iid: int) -> list[dict[str, Any]]:
+    """Return all comments for a merge request."""
+    resp = requests.get(
+        f"{GITLAB_API_URL}/projects/{project_id}/merge_requests/{mr_iid}/notes",
+        headers=_headers(),
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def add_merge_request_comment(project_id: int, mr_iid: int, body: str) -> dict[str, Any]:
+    """Add a comment to a merge request."""
+    resp = requests.post(
+        f"{GITLAB_API_URL}/projects/{project_id}/merge_requests/{mr_iid}/notes",
+        headers=_headers(),
+        json={"body": body},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_merge_request_pipeline_status(project_id: int, mr_iid: int) -> Optional[str]:
+    """Return the status of the latest pipeline for a merge request."""
+    resp = requests.get(
+        f"{GITLAB_API_URL}/projects/{project_id}/merge_requests/{mr_iid}/pipelines",
+        headers=_headers(),
+    )
+    resp.raise_for_status()
+    pipelines = resp.json()
+    if not pipelines:
+        return None
+    return pipelines[0].get("status")

--- a/clean_mcp_init/clean_mcp_init/mcp_tools.py
+++ b/clean_mcp_init/clean_mcp_init/mcp_tools.py
@@ -1,7 +1,37 @@
-# clean_mcp_init/mcp_tools.py
-from django_mcp import mcp_app as mcp   # same FastMCP instance the ASGI app uses
+"""MCP tool definitions."""
+
+from __future__ import annotations
+
+from django_mcp import mcp_app as mcp
+
+from . import gitlab_utils
+
 
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers and return the result."""
     return a + b
+
+
+@mcp.tool()
+def gitlab_get_merge_requests(project_id: int, branch_name: str):
+    """Return merge requests for a branch."""
+    return gitlab_utils.get_merge_requests(project_id, branch_name)
+
+
+@mcp.tool()
+def gitlab_get_merge_request_comments(project_id: int, merge_request_iid: int):
+    """Return comments for a merge request."""
+    return gitlab_utils.get_merge_request_comments(project_id, merge_request_iid)
+
+
+@mcp.tool()
+def gitlab_add_comment(project_id: int, merge_request_iid: int, body: str):
+    """Add a comment to a merge request."""
+    return gitlab_utils.add_merge_request_comment(project_id, merge_request_iid, body)
+
+
+@mcp.tool()
+def gitlab_pipeline_status(project_id: int, merge_request_iid: int):
+    """Return the latest pipeline status for a merge request."""
+    return gitlab_utils.get_merge_request_pipeline_status(project_id, merge_request_iid)

--- a/clean_mcp_init/clean_mcp_init/wsgi.py
+++ b/clean_mcp_init/clean_mcp_init/wsgi.py
@@ -1,11 +1,4 @@
-"""
-WSGI config for clean_mcp_init project.
-
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
-"""
+"""WSGI config for clean_mcp_init project."""
 
 import os
 

--- a/clean_mcp_init/requirements.txt
+++ b/clean_mcp_init/requirements.txt
@@ -3,4 +3,5 @@ fastmcp==2.9.2          # stays on the MCP 1.9 spec
 django-mcp==0.3.1
 mcp==1.9.4              # latest 1.9.x release; satisfies both libs
 uvicorn==0.35.0         # ASGI runner if you serve Django directly
-daphne==4.2.1 
+daphne==4.2.1
+requests==2.31.0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,26 @@
+import asyncio
+import sys
+from django.test import SimpleTestCase
+
+sys.path.append('clean_mcp_init')
+
+import clean_mcp_init.asgi  # noqa: F401  - ensures application loads
+import clean_mcp_init.mcp_tools  # noqa: F401 - registers tools
+import django_mcp
+
+
+class MCPServerTests(SimpleTestCase):
+    def test_application_loads(self):
+        self.assertIsNotNone(clean_mcp_init.asgi.application)
+
+    def test_tools_registered(self):
+        tools = asyncio.run(django_mcp.mcp_app.list_tools())
+        names = {t.name for t in tools}
+        expected = {
+            'add',
+            'gitlab_get_merge_requests',
+            'gitlab_get_merge_request_comments',
+            'gitlab_add_comment',
+            'gitlab_pipeline_status',
+        }
+        self.assertTrue(expected.issubset(names))


### PR DESCRIPTION
## Summary
- document project with new README
- add GitLab API tools
- update ASGI/WSGI files
- update requirements and CI workflow
- add tests verifying tool registration

## Testing
- `python clean_mcp_init/manage.py test tests`

------
https://chatgpt.com/codex/tasks/task_e_686d0557b460832f850fa03406dd792e